### PR TITLE
Rename Model to Substore

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Test your functional views independent of your state, test your state independen
 
 ## Building Blocks
 
-The mobx-reactor building blocks are a `Store`, composed of `Model` objects, together with `Action` methods connected to React components through a `StoreContext` and a `connect` wrapper.
+The mobx-reactor building blocks are a `Store`, composed of `Substore` objects, together with `Action` methods connected to React components through a `StoreContext` and a `connect` wrapper.
 
 ### Store
 
-A single shared `Store` holds application state and provides a method to `dispatch` actions to affect application logic. The `store` is assembled from `Model` sub-objects that each define and manage a piece of the application state. A `Store` can be configured with `middleware` that provides an extension point for performing activities like logging and crash reporting.
+A single shared `Store` holds application state and provides a method to `dispatch` actions to affect application logic. The `store` is assembled from `Substore` sub-objects that each define and manage a piece of the application state. A `Store` can be configured with `middleware` that provides an extension point for performing activities like logging and crash reporting.
 
 
 ```javascript
@@ -49,12 +49,12 @@ const store = new Store(
 > The logger currently requires you to first `npm install deep-diff`.
 
 
-### Models
+### Substores
 
-A `Model` provides a construct to organize state with methods that operate on that state in response to relevant actions. A model objects are a vehicle for organization, not encapsulation. While all state is defined through models, actions can be defined as part of a model or independently of a model.
+A `Substore` provides a construct to organize state in sub-stores with methods that operate on that state in response to relevant actions. A sub-store objects are a vehicle for organization, not encapsulation. While all state is defined through this stores, actions can be defined as part of a store or independently of a store.
 
 ```javascript
-class TodoList extends Model {
+class TodoList extends Substore {
   @observable todos = map({});
 
   @computed get unfinishedTodoCount() {

--- a/examples/auth/index.js
+++ b/examples/auth/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom'
 import { v4 as uuid } from 'uuid'
 
 import { observable, computed, map } from 'mobx'
-import { Store, logger, StoreContext, Model, action, dispatch, call, connect } from 'mobx-reactor'
+import { Store, logger, StoreContext, Substore, action, dispatch, call, connect } from 'mobx-reactor'
 import { exemplar } from 'mobx-reactor/middleware/exemplar'
 
 // Auth "Lib"
@@ -24,9 +24,9 @@ function sleep(n) {
   }, n))
 }
 
-// Models + Actions
+// Sub-store + Actions
 
-class Auth extends Model {
+class Auth extends Substore {
   @observable status = 'UNAUTHORIZED';
   @observable token = '';
   @observable userId = '';

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -3,10 +3,9 @@ import ReactDOM from 'react-dom'
 import { v4 as uuid } from 'uuid'
 
 import { observable, computed, map } from 'mobx'
-import { Store, logger, StoreContext, Model, action, connect, serialize } from 'mobx-reactor'
+import { Store, logger, StoreContext, Substore, action, connect, serialize } from 'mobx-reactor'
 
-// Models + Actions
-
+// Model
 class Todo {
   id = uuid()
   @observable title
@@ -19,7 +18,9 @@ class Todo {
   }
 }
 
-class TodoList extends Model {
+// Sub-store + Actions
+
+class TodoList extends Substore {
   @observable todos = map()
 
   @computed get unfinishedTodoCount() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { observable, computed } from 'mobx'
-import { Model, action, dispatch, call } from './model'
+import { Substore, action, dispatch, call } from './substore'
 import { Store } from './store'
 import { logger } from './middleware/logger'
 import { StoreContext } from './storeContext'
@@ -8,7 +8,7 @@ import { serialize } from './serialize'
 
 export {
   connect,
-  Model,
+  Substore,
   action,
   dispatch,
   call,

--- a/src/substore.js
+++ b/src/substore.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { observable, computed, autorun } from 'mobx'
 import { autobind } from 'core-decorators'
 
-export class Model {
+export class Substore {
   constructor() {
   }
 }

--- a/tests/testStore.js
+++ b/tests/testStore.js
@@ -1,12 +1,12 @@
 import test from 'ava'
 
 import { observable, map } from 'mobx'
-import { Model, action } from '../src/model'
+import { Substore, action } from '../src/substore'
 import { Store } from '../src/store'
 
 test(t => {
   let nextPersonId = 1
-  class Person extends Model {
+  class Person extends Substore {
     @observable name = ''
     constructor(name) {
       super()
@@ -15,7 +15,7 @@ test(t => {
     }
   }
 
-  class Contacts extends Model {
+  class Contacts extends Substore {
     @observable people = map()
 
     @action('addPerson')


### PR DESCRIPTION
How about rename Model to Substore ?
In basic example Todo is model, but TodoList is not. TodoList is store of models.
